### PR TITLE
Bugfix/internal content link

### DIFF
--- a/content/articles/1912-announce-tutorial.md
+++ b/content/articles/1912-announce-tutorial.md
@@ -5,9 +5,9 @@ Category: General
 In the coming sciwork conference, we are planning for two hands-on tutorials to
 introduce important programming skills to the audience:
 
-- [Hypothesis Testing with Python](../../tutorial/hypothesis-testing.html)
+- [Hypothesis Testing with Python]({filename}/pages/tutorial/hypothesis-testing.rst)
   (Mosky Liu)
-- [Packaging: Share your code for pip and Conda](../../tutorial/packaging.html)
+- [Packaging: Share your code for pip and Conda]({filename}/pages/tutorial/packaging.rst)
   (Tzu-Ping Chung)
 
 The lecturers have a lot of experience, and will guide the attendees to explore

--- a/content/pages/index.rst
+++ b/content/pages/index.rst
@@ -3,7 +3,7 @@ Sciwork 2020 - Welcome
 ======================
 
 :date: 2019-07-19 20:00
-:url:
+:url: index.html
 :save_as: index.html
 
 

--- a/content/pages/program.rst
+++ b/content/pages/program.rst
@@ -3,7 +3,7 @@ Program
 =======
 
 :date: 2019-07-19 20:00
-:url:
+:url: program.html
 :save_as: program.html
 
 Program

--- a/content/pages/prospectus.rst
+++ b/content/pages/prospectus.rst
@@ -3,6 +3,7 @@ Sciwork Prospectus
 ==================
 
 :date: 2019-12-19 08:00
+:url: prospectus.html
 :save_as: prospectus.html
 
 .. |br| raw:: html

--- a/content/pages/sponsors.rst
+++ b/content/pages/sponsors.rst
@@ -3,7 +3,7 @@ Sciwork Sponsorship
 ===================
 
 :date: 2019-12-19 08:00
-:url:
+:url: sponsors.html
 :save_as: sponsors.html
 
 Solicit Sponsorship

--- a/content/pages/sprint/libst.rst
+++ b/content/pages/sprint/libst.rst
@@ -3,7 +3,7 @@ Sprint - libst
 ==============
 
 :date: 2019-12-17 12:00
-:url:
+:url: sprint/libst.html
 :save_as: sprint/libst.html
 
 .. _libst: https://github.com/yungyuc/turgon

--- a/content/pages/sprint/uni10.rst
+++ b/content/pages/sprint/uni10.rst
@@ -3,7 +3,7 @@ Sprint - Uni10
 ==============
 
 :date: 2019-12-17 12:00
-:url:
+:url: sprint/uni10.html
 :save_as: sprint/uni10.html
 
 .. _Uni10: https://gitlab.com/uni10/uni10

--- a/content/pages/tutorial/hypothesis-testing.rst
+++ b/content/pages/tutorial/hypothesis-testing.rst
@@ -3,7 +3,7 @@ Tutorial - Hypothesis Testing in Python
 =======================================
 
 :date: 2019-12-18 12:00
-:url:
+:url: tutorial/hypothesis-testing.html
 :save_as: tutorial/hypothesis-testing.html
 
 Tutorial - Hypothesis Testing in Python

--- a/content/pages/tutorial/packaging.rst
+++ b/content/pages/tutorial/packaging.rst
@@ -3,7 +3,7 @@ Tutorial - Packaging: Share your code for pip and Conda
 =======================================================
 
 :date: 2019-12-18 12:00
-:url:
+:url: tutorial/packaging.html
 :save_as: tutorial/packaging.html
 
 Tutorial - Packaging: Share your code for pip and Conda

--- a/content/pages/venue.rst
+++ b/content/pages/venue.rst
@@ -2,7 +2,7 @@ Venue
 =====
 
 :date: 2019-9-22 8:00
-:url:
+:url: venue.html
 :save_as: venue.html
 
 The conference is planned to be held in `National Chiao Tung University

--- a/mytheme/templates/base.html
+++ b/mytheme/templates/base.html
@@ -43,8 +43,19 @@
           <li><div class="divider"> </div></li>
           {% endif %}
 
+          {% if output_file == 'index.html' %}
+            {% set active_title = 'welcome' %}
+          {% elif output_file.startswith('blog') or output_file.startswith('articles') %}
+            {% set active_title = 'blog' %}
+          {% elif output_file.startswith('sprint') or output_file.startswith('tutorial') %}
+            {% set active_title = 'program' %}
+          {% elif output_file == 'prospectus.html' %}
+            {% set active_title = 'sponsors' %}
+          {% else %}
+            {% set active_title = output_file.replace('.html', '') %}
+          {% endif %}
           {% for title, link in MENUITEMS %}
-          <li {% if output_file == link or title|upper == page_name|upper %}class="active"{% endif %}>
+          <li {% if active_title == title|lower %}class="active"{% endif %}>
             <a href="{{ SITEURL }}/{{ link }}">{{ title }}</a>
           </li>
           {% endfor %}

--- a/mytheme/templates/index.html
+++ b/mytheme/templates/index.html
@@ -27,9 +27,11 @@
     {% for article in articles_page.object_list %}
       <div class="row">
         <div class="col s12 card">
-          <div class="article-title">{{ article.title }}</div>
-          {% include 'article_infos.html' %}
           <div class="card-content">
+            <div class="article-title">
+              <a class="grey-text text-darken-3" href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a>
+            </div>
+            {% include 'article_infos.html' %}
             {{ article.summary }}
           </div>
           <div class="card-action">


### PR DESCRIPTION
Related issue: #39

See: https://github.com/getpelican/pelican/blob/master/pelican/contents.py#L287

Pelican use the `url` metadata to generated pages URL.

And we overrided the location it is saved in, then `url` metadata should be the same as `save_as`.